### PR TITLE
Add .gitignore to exclude compiled sources and IDE specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Entries taken from: https://gist.github.com/dedunumax/54e82214715e35439227
+
+##############################
+## Java
+##############################
+.mtj.tmp/
+*.class
+*.jar
+*.war
+*.ear
+*.nar
+hs_err_pid*
+
+##############################
+## Maven
+##############################
+target/
+
+##############################
+## IntelliJ
+##############################
+out/
+.idea/
+.idea_modules/
+*.iml
+*.ipr
+*.iws
+
+##############################
+## Eclipse
+##############################
+.settings/
+bin/
+tmp/
+.metadata
+.classpath
+.project
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.loadpath
+.factorypath
+
+##############################
+## NetBeans
+##############################
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+##############################
+## Visual Studio Code
+##############################
+.vscode/
+.code-workspace
+
+##############################
+## OS X
+##############################
+.DS_Store


### PR DESCRIPTION
### Description of the Change

Added a .gitignore file so that unwanted compiled sources and IDE specific files are not accidentally committed.

### Benefits

Prevents unwanted compiled sources and IDE specific files from being accidentally committed.

###Verification Process
Verified that no files currently conflict with .gitignore using `git status --ignored`.

